### PR TITLE
Turn this into a proper package with a vex-reader command entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,30 @@ You can install [vex-reader](https://pypi.org/project/vex-reader/) by:
 
 ## Installation
 
-```pip install vex-reader```
+Install from PyPI:
+
+```shell
+pip install vex-reader
+```
+
+Development setup:
+
+```shell
+git clone https://github.com/vdanen/vex-reader.git
+cd vex-reader
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -e .
+```
 
 ## Usage
 
 You can use the vex library in your own python applications or you can
 clone this repo and use the vex-reader.py script to parse VEX files.
 
-```
-python3 vex-reader.py --vex tests/cve-2002-2443.json
+```shell
+$ vex-reader --vex tests/cve-2002-2443.json
 CVE-2002-2443
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "rich>=13.7.1",
 ]
 
+[project.scripts]
+vex-reader = "vex.vex_reader:main"
+
 [project.urls]
 Homepage = "https://github.com/vdanen/vex-reader"
 Issues = "https://github.com/vdanen/vex-reader/issues"

--- a/vex/vex_reader.py
+++ b/vex/vex_reader.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Read and process a VEX document
 # i.e. https://access.redhat.com/security/data/csaf/beta/vex/2024/cve-2024-21626.json
 
@@ -7,10 +5,12 @@ import argparse
 import requests
 from rich.console import Console
 from rich.markdown import Markdown
-from vex import Vex
-from vex import VexPackages
-from vex import NVD
-from vex.constants import SEVERITY_COLOR
+
+from .vex import Vex
+from .package import VexPackages
+from .simplenvd import NVD
+from .constants import SEVERITY_COLOR
+
 
 def main():
     parser = argparse.ArgumentParser(description='VEX Parser')
@@ -134,7 +134,7 @@ def main():
 
         console.print(f'[green]CVSS {vex.cvss_type} Score Breakdown[/green]')
         # TODO: string padding
-        print(f'{' ':26} {publisher:<10} NVD')
+        print(f"{' ':26} {publisher:<10} NVD")
         if vex.cvss_type == 'v3':
             print(f"  {'CVSS v3 Base Score':24} {vex.global_cvss['baseScore']:<10} {nvd.baseScore}")
             if 'attackVector' in vex.global_cvss:


### PR DESCRIPTION
This moves the vex-reader file into the vex package and adds an entrypoint into the main function for the vex-reader command.

Also, the nested single quote syntax used in one of the prints is only supported in Python 3.12 or later, so change that to double-quotes on the outside to make this compatible with the advertised, older Python versions.